### PR TITLE
Fix se-education.org hyperlink, slight phrasing improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **CaseTrack is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
 
-* If you are interested in using CaseTrack, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
-* If you are interested about developing CaseTrack, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
+* If you are interested in using CaseTrack, head over to the [_Quick Start_ section of the **User Guide**](https://ay2526s1-cs2103-f12-3.github.io/tp/UserGuide.html#quick-start).
+* If you are interested about developing CaseTrack, the [**Developer Guide**](https://ay2526s1-cs2103-f12-3.github.io/tp/DeveloperGuide.html) is a good place to start.
 * This project is a **part of the se-education.org** initiative. If you would like to contribute code to the parent project, see [se-education.org](https://se-education.org/#contributing-to-se-edu) for more info.
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).


### PR DESCRIPTION
- Preserve original format for crediting se-education project
- Highlight that the link contributes to the original parent project of CaseTrack, but not CaseTrack itself.
- Fix relative links on the readme not correctly redirecting to the Github Page site.